### PR TITLE
add paper version for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This template provides a clean and professional layout that follows FEUP's thesi
   language: "en",
   has-quote: true,
   bib-style: "ieee",
+  on-paper: true,
 )
 ```
 

--- a/src/template.typ
+++ b/src/template.typ
@@ -1,7 +1,7 @@
 // INVICTA THESIS TEMPLATE
 // Main template function and document setup
 
-#import "covers.typ": make-cover, make-committee-page
+#import "covers.typ": make-committee-page, make-cover
 #import "toc.typ": make-toc
 
 // Main template function
@@ -12,31 +12,26 @@
   degree: "<DEGREE>",
   supervisor: "<SUPERVISOR>",
   second-supervisor: none,
-  
   // Dates and copyright
   thesis-date: none, // If none, current date will be used
   copyright-notice: none,
-  
   // Visual elements
   additional-front-text: none,
-  
   // Committee information
   committee-text: none, // Put text if final version
   committee-members: (),
-  signature: false,   // true if handwritten signature 
+  signature: false, // true if handwritten signature
   dedication-text: none, // Optional dedication
-
   // Configuration options
   stage: "preparation", // "preparation", "juri", "final"
   language: "en", // "en", "pt"
   has-unsdg: false, // true if your thesis has united nations sustainable development goals
-  has-quote: true,  // true if your thesis has a quote
+  has-quote: true, // true if your thesis has a quote
   bib-style: "ieee", // bibliography style: e.g, "apa", "chicago-notes", "mla"
-  
+  on-paper: false, // if true, links are not shown (for paper versions)
   // Document body
-  body
+  body,
 ) = {
-  
   // Create configuration object
   let config = (
     title: title,
@@ -96,23 +91,23 @@
     #v(2em)
     #if it.numbering != none {
       let chapter_num = counter(heading).get().first()
-      
+
       // Check if this is an appendix by looking at the numbering pattern
       if it.numbering == "A.1" {
         // Convert number to letter (1=A, 2=B, etc.)
         let appendix_letter = str.from-unicode(65 + chapter_num - 1) // 65 is ASCII for 'A'
         block(
-          text(size: 20pt, weight: "bold", [Appendix #appendix_letter])
+          text(size: 20pt, weight: "bold", [Appendix #appendix_letter]),
         )
       } else {
         block(
-          text(size: 20pt, weight: "bold", [Chapter #chapter_num])
+          text(size: 20pt, weight: "bold", [Chapter #chapter_num]),
         )
       }
     }
     #v(1em)
     #block(
-      text(size: 26pt, weight: "bold", it.body)
+      text(size: 26pt, weight: "bold", it.body),
     )
     #v(2em)
   ]
@@ -131,7 +126,10 @@
   )
 
   // Link formatting
-  show link: it => text(fill: blue, it)
+  show link: it => text(
+    fill: if on-paper { blue } else { black },
+    it,
+  )
 
   // Generate the document
   // Main document structure
@@ -152,32 +150,38 @@
     header: context {
       let current-page = here().page()
       let page-number = counter(page).at(here()).first()
-      
+
       // Don't show header on chapter start pages
       let all-headings = query(heading)
-      
+
       for h in all-headings {
         if h.level == 1 and h.location().page() == current-page {
           return align(right)[#text(size: 11pt)[#page-number]]
         }
       }
-      
+
       // Get current chapter and section
-      let chapter-headings = all-headings.filter(h => h.level == 1 and h.location().page() <= current-page)
-      let section-headings = all-headings.filter(h => h.level == 2 and h.location().page() <= current-page)
-      
+      let chapter-headings = all-headings.filter(h => (
+        h.level == 1 and h.location().page() <= current-page
+      ))
+      let section-headings = all-headings.filter(h => (
+        h.level == 2 and h.location().page() <= current-page
+      ))
+
       let header-content = none
       if chapter-headings.len() > 0 {
         let current-chapter = chapter-headings.last()
         let chapter-counter = counter(heading).at(current-chapter.location())
         let chapter-num = chapter-counter.first()
-        
+
         // Check if this is odd or even page
         if calc.odd(current-page) {
           // Odd pages: show current subsection (if any)
           if section-headings.len() > 0 {
             let current-section = section-headings.last()
-            let section-counter = counter(heading).at(current-section.location())
+            let section-counter = counter(heading).at(
+              current-section.location(),
+            )
             header-content = text(size: 10pt, style: "italic")[
               #section-counter.first().#section-counter.at(1) #current-section.body
             ]
@@ -194,15 +198,14 @@
           ]
         }
       }
-      
+
       // Create header with content on left and page number on right
       grid(
         columns: (1fr, auto),
         align: (left, right),
-        header-content,
-        text(size: 11pt)[#page-number]
+        header-content, text(size: 11pt)[#page-number],
       )
-    }
+    },
   )
   #counter(page).update(1)
 ]
@@ -215,32 +218,38 @@
     header: context {
       let current-page = here().page()
       let page-number = counter(page).at(here()).first()
-      
+
       // Don't show header on chapter start pages
       let all-headings = query(heading)
-      
+
       for h in all-headings {
         if h.level == 1 and h.location().page() == current-page {
           return align(right)[#text(size: 11pt)[#page-number]]
         }
       }
-      
+
       // Get current chapter and section
-      let chapter-headings = all-headings.filter(h => h.level == 1 and h.location().page() <= current-page)
-      let section-headings = all-headings.filter(h => h.level == 2 and h.location().page() <= current-page)
-      
+      let chapter-headings = all-headings.filter(h => (
+        h.level == 1 and h.location().page() <= current-page
+      ))
+      let section-headings = all-headings.filter(h => (
+        h.level == 2 and h.location().page() <= current-page
+      ))
+
       let header-content = none
       if chapter-headings.len() > 0 {
         let current-chapter = chapter-headings.last()
         let chapter-counter = counter(heading).at(current-chapter.location())
         let chapter-num = chapter-counter.first()
-        
+
         // Check if this is odd or even page
         if calc.odd(current-page) {
           // Odd pages: show current subsection (if any)
           if section-headings.len() > 0 {
             let current-section = section-headings.last()
-            let section-counter = counter(heading).at(current-section.location())
+            let section-counter = counter(heading).at(
+              current-section.location(),
+            )
             header-content = text(size: 10pt, style: "italic")[
               #section-counter.first().#section-counter.at(1) #current-section.body
             ]
@@ -257,15 +266,14 @@
           ]
         }
       }
-      
+
       // Create header with content on left and page number on right
       grid(
         columns: (1fr, auto),
         align: (left, right),
-        header-content,
-        text(size: 11pt)[#page-number]
+        header-content, text(size: 11pt)[#page-number],
       )
-    }
+    },
   )
   counter(page).update(1)
   body

--- a/template/main.typ
+++ b/template/main.typ
@@ -7,14 +7,14 @@
   degree: "<YOUR COURSE NAME>",
   supervisor: "<SUPERVISOR NAME>",
   second-supervisor: "<SECOND SUPERVISOR NAME>", // Optional, use none if not applicable
-  
+
   // Dates and copyright
   thesis-date: none, // Will use current date
   copyright-notice: "<YOUR NAME>, <YEAR OF PUBLICATION>",
-  
+
   // Visual elements
   additional-front-text: none,
-  
+
   // Committee information (example for final version), use none otherwise
   committee-text: "Approved in oral examination by the committee:",
   committee-members: (
@@ -23,13 +23,14 @@
     (role: "Referee", name: "<COMMITTEE MEMBER NAME>"),
   ),
   signature: false,
-  
+
   // Configuration options
   stage: "final", // This is a final version
   language: "en",
   has-unsdg: false, // Include UN SDG section
   has-quote: true,
   bib-style: "ieee",
+  on-paper: false, // Links will be shown
 )
 
 // Optional, remove this if you don't want a dedication
@@ -55,7 +56,7 @@
 // Quote
 #feup.epigraph(
   "The best way to predict the future is to invent it.",
-  "Alan Kay"
+  "Alan Kay",
 )
 
 // Table of Contents
@@ -63,18 +64,17 @@
 
 // List of Acronyms
 #feup.acronym-list((
-    ("AI", "Artificial Intelligence"),
-    ("API", "Application Programming Interface"),
-    ("CNN", "Convolutional Neural Network"),
-    ("CPU", "Central Processing Unit"),
-    ("GPU", "Graphics Processing Unit"),
-    ("ML", "Machine Learning"),
-    ("NLP", "Natural Language Processing"),
-    ("RNN", "Recurrent Neural Network"),
-    ("SGD", "Stochastic Gradient Descent"),
-    ("UI", "User Interface"),
-  ),
-)
+  ("AI", "Artificial Intelligence"),
+  ("API", "Application Programming Interface"),
+  ("CNN", "Convolutional Neural Network"),
+  ("CPU", "Central Processing Unit"),
+  ("GPU", "Graphics Processing Unit"),
+  ("ML", "Machine Learning"),
+  ("NLP", "Natural Language Processing"),
+  ("RNN", "Recurrent Neural Network"),
+  ("SGD", "Stochastic Gradient Descent"),
+  ("UI", "User Interface"),
+))
 
 // Start main body with arabic numbering
 <main-content>


### PR DESCRIPTION
Adds an option on template to change link color for the paper version

`on-paper: true`
<img width="730" height="98" alt="image" src="https://github.com/user-attachments/assets/136bca4d-272c-4335-ab21-bf8fec7cfddb" />

`on-paper: false`
<img width="730" height="98" alt="image" src="https://github.com/user-attachments/assets/fda4ce9c-f2bb-4162-97ab-38d9ae0777c0" />

closes #4 