### PR TITLE
fix bib pagebreak

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -67,7 +67,6 @@
   )
   
   bibliography("../template/refs.bib", style: style, title: "References")
-  pagebreak()
 }
 
 // Export main content wrapper that retrieves config from state


### PR DESCRIPTION
removed the pagebreak in bibliography, due to adding a blank page at the end